### PR TITLE
[BE] FEAT: 꿈 일기 이미지 생성 API 구현

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,8 @@
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/swagger": "^6.3.0",
     "@nestjs/typeorm": "^9.0.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
     "mysql": "^2.18.1",
     "openai": "^3.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^10.0.3",
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/schedule": "^2.2.2",
     "@nestjs/swagger": "^6.3.0",
     "@nestjs/typeorm": "^9.0.1",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { CommentModule } from './comment/comment.module';
 import TypeOrmConfigService from './config/typeorm.config';
 import { ProfileModule } from './profile/profile.module';
 import { UtilModule } from './util/util.module';
+import { DreamDiaryModule } from './dreamdiary/dreamdiary.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { UtilModule } from './util/util.module';
     ProfileModule,
     CommentModule,
     UtilModule,
+    DreamDiaryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/dreamdiary/dreamdiary.controller.ts
+++ b/backend/src/dreamdiary/dreamdiary.controller.ts
@@ -3,7 +3,9 @@ import {
   Controller,
   ForbiddenException,
   InternalServerErrorException,
+  Logger,
   Post,
+  UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
 import {
@@ -12,14 +14,19 @@ import {
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiOperation,
+  ApiTags,
 } from '@nestjs/swagger';
 import { GetUser } from 'src/decorator/user.decorator';
 import { GenerateDreamDiaryImagesRequestDto } from 'src/dto/generate.dreamdiary.images.request.dto';
 import { UserDto } from 'src/dto/user.dto';
 import { DreamDiaryService } from './dreamdiary.service';
+import { AuthGuard } from '@nestjs/passport';
+import { GeneratedImagesResponseDto } from 'src/dto/generated.images.response.dto';
 
+@ApiTags('DreamDiary')
 @Controller('dream-diary')
 export class DreamDiaryController {
+  private readonly logger = new Logger(DreamDiaryController.name);
   constructor(private readonly dreamDiaryService: DreamDiaryService) {}
 
   @ApiOperation({
@@ -40,41 +47,23 @@ export class DreamDiaryController {
       '무료 이미지 생성 횟수를 초과한 경우, 403 Forbidden을 반환합니다.',
   })
   @Post('dream-images')
+  @UseGuards(AuthGuard('jwt'))
   async createDreamDiaryImages(
     @Body(new ValidationPipe())
     generateDreamDiaryImagesRequestDto: GenerateDreamDiaryImagesRequestDto,
     @GetUser() user: UserDto,
-  ) {
+  ): Promise<GeneratedImagesResponseDto> {
     try {
-      // 서비스에서 처리하는게 좋으려나..?
-      // TODO: 무료 이미지 생성 횟수, 최대 무료 생성 가능 횟수를 얻어온다.
-      // FIXME: 실제 받아오는 데이터로 변경해야 함.
-      const freeGenerateCount = 0;
-      const maxFreeGenerateCount = 3;
-
-      // TODO: 무료 생성 횟수를 초과했다면, 유저의 크레딧 정보를 얻어온다.
-      // TODO: 크레딧도 없다면 에러를 반환한다.
-      const credits = 1;
-      if (credits <= 0) {
-        throw new ForbiddenException(
-          '무료 이미지 생성 횟수를 초과했습니다. 추가로 이용하시려면 크레딧을 충전해주세요.',
-        );
-      }
-
-      const generatedImages =
-        await this.dreamDiaryService.createDreamDiaryImages(
-          generateDreamDiaryImagesRequestDto.title,
-          generateDreamDiaryImagesRequestDto.content,
-          user.userId,
-        );
-
-      return {
-        credits,
-        freeGenerateCount,
-        maxFreeGenerateCount,
-        generatedImages,
-      };
+      return await this.dreamDiaryService.createDreamDiaryImages(
+        generateDreamDiaryImagesRequestDto.title,
+        generateDreamDiaryImagesRequestDto.content,
+        user.userId,
+      );
     } catch (err) {
+      this.logger.error(err.message);
+      if (err instanceof ForbiddenException) {
+        throw new ForbiddenException(err.message);
+      }
       throw new InternalServerErrorException(err.message);
     }
   }

--- a/backend/src/dreamdiary/dreamdiary.module.ts
+++ b/backend/src/dreamdiary/dreamdiary.module.ts
@@ -3,15 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DreamDiaryService } from './dreamdiary.service';
 import { DreamDiary } from 'src/entities/dream.diary.entity';
 import { DreamDiaryController } from './dreamdiary.controller';
-import { User } from 'src/entities/user.entity';
 import { DiaryCategory } from 'src/entities/diary.category.entity';
 import { UtilModule } from 'src/util/util.module';
-import { ImageRequests } from 'src/entities/image.requests.entity';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([DreamDiary, User, DiaryCategory, ImageRequests]),
+    TypeOrmModule.forFeature([DreamDiary, DiaryCategory]),
     UtilModule,
+    UserModule,
   ],
   controllers: [DreamDiaryController],
   providers: [DreamDiaryService],

--- a/backend/src/dreamdiary/dreamdiary.module.ts
+++ b/backend/src/dreamdiary/dreamdiary.module.ts
@@ -1,16 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { AuthModule } from 'src/auth/auth.module';
 import { DreamDiaryService } from './dreamdiary.service';
 import { DreamDiary } from 'src/entities/dream.diary.entity';
 import { DreamDiaryController } from './dreamdiary.controller';
 import { User } from 'src/entities/user.entity';
 import { DiaryCategory } from 'src/entities/diary.category.entity';
 import { UtilModule } from 'src/util/util.module';
+import { ImageRequests } from 'src/entities/image.requests.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([DreamDiary, User, DiaryCategory]),
+    TypeOrmModule.forFeature([DreamDiary, User, DiaryCategory, ImageRequests]),
     UtilModule,
   ],
   controllers: [DreamDiaryController],

--- a/backend/src/dreamdiary/dreamdiary.service.ts
+++ b/backend/src/dreamdiary/dreamdiary.service.ts
@@ -57,7 +57,7 @@ export class DreamDiaryService {
 
     // const images = await this.oepnAIService.createImage(prompt, 1, '512x512');
     const images = [
-      'https://images.unhttps://avatars.githubusercontent.com/u/31301280?s=200&v=4splash.com/photo-1621574539437-4b5b5b5b5b5b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMjI0NjB8MHwxfHNlYXJjaHwxfHxkcmVhbXN0aW9ufGVufDB8fHx8MTYyMjE0NjY5Mg&ixlib=rb-1.2.1&q=80&w=1080',
+      'https://avatars.githubusercontent.com/u/31301280?s=200&v=4splash.com/photo-1621574539437-4b5b5b5b5b5b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMjI0NjB8MHwxfHNlYXJjaHwxfHxkcmVhbXN0aW9ufGVufDB8fHx8MTYyMjE0NjY5Mg&ixlib=rb-1.2.1&q=80&w=1080',
     ];
 
     return {

--- a/backend/src/dreamdiary/dreamdiary.service.ts
+++ b/backend/src/dreamdiary/dreamdiary.service.ts
@@ -1,19 +1,83 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Configuration, OpenAIApi } from 'openai';
+import { GeneratedImagesResponseDto } from 'src/dto/generated.images.response.dto';
+import { ImageRequests } from 'src/entities/image.requests.entity';
+import { User } from 'src/entities/user.entity';
 import { OpenAIService } from 'src/util/openai.service';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class DreamDiaryService {
   private readonly logger = new Logger(DreamDiaryService.name);
 
-  constructor(private readonly oepnAIService: OpenAIService) {}
+  constructor(
+    private readonly oepnAIService: OpenAIService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(ImageRequests)
+    private readonly imageRequestsRepository: Repository<ImageRequests>,
+  ) {}
 
-  async createDreamDiaryImages(title: string, content: string, userId: number) {
+  async getUserWithImageRequestsInfo(userId: number): Promise<User> {
+    this.logger.debug(`Called ${this.getUserWithImageRequestsInfo.name}`);
+
+    const result = await this.userRepository.findOne({
+      where: {
+        userId,
+      },
+      relations: ['imageRequests'],
+    });
+    console.log(result.imageRequests.curRequestCount);
+    console.log(result.imageRequests.maxRequestCount);
+    console.log(result.credits);
+    return result;
+  }
+
+  async createDreamDiaryImages(
+    title: string,
+    content: string,
+    userId: number,
+  ): Promise<GeneratedImagesResponseDto> {
     this.logger.debug(`Called ${this.createDreamDiaryImages.name}`);
+
+    const result = await this.getUserWithImageRequestsInfo(userId);
+    const maxRequestCount = result.imageRequests.maxRequestCount;
+    let curRequestCount = result.imageRequests.curRequestCount;
+    let credits = result.credits;
+
+    if (curRequestCount + 1 > maxRequestCount) {
+      if (credits <= 0) {
+        throw new ForbiddenException(
+          '무료 이미지 생성 횟수를 초과했습니다. 추가로 이용하시려면 크레딧을 충전해주세요.',
+        );
+      }
+      --credits;
+      await this.userRepository.update(
+        {
+          userId,
+        },
+        {
+          credits,
+        },
+      );
+    } else {
+      ++curRequestCount;
+      await this.imageRequestsRepository.update(
+        {
+          userId,
+        },
+        {
+          curRequestCount,
+        },
+      );
+    }
 
     // TODO: prompt를 어떻게 만들어야 할지 고민해보기
     // FIXME: GPT가 만들어주는 프롬프트로 받아서 사용해야 함.
+    title;
+    content;
     const prompt = `
     Captures two individuals in the office, one of them pointing a gun at the other.
     Portray a sense of mystery and suspense.
@@ -26,10 +90,13 @@ export class DreamDiaryService {
     This photo could be used in a suspense or mystery-themed publication, a corporate thriller, or a psychological drama.
 `;
 
-    const blobImages = await this.oepnAIService.createImage(
-      prompt,
-      1,
-      '512x512',
-    );
+    const images = await this.oepnAIService.createImage(prompt, 1, '512x512');
+
+    return {
+      credits,
+      freeGenerateCount: curRequestCount,
+      maxFreeGenerateCount: maxRequestCount,
+      generatedImages: images,
+    } as GeneratedImagesResponseDto;
   }
 }

--- a/backend/src/dto/credit.info.dto.ts
+++ b/backend/src/dto/credit.info.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreditInfoDto {
+  @ApiProperty({
+    example: 0,
+    description: '사용자의 현재 크레딧',
+  })
+  credits: number;
+
+  @ApiProperty({
+    example: 0,
+    description: '사용자의 현재 무료 이미지 생성 횟수',
+  })
+  freeGenerateCount: number;
+
+  @ApiProperty({
+    example: 3,
+    description: '사용자의 최대 무료 이미지 생성 횟수',
+  })
+  maxFreeGenerateCount: number;
+}

--- a/backend/src/dto/credit.info.response.dto.ts
+++ b/backend/src/dto/credit.info.response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreditInfoDto } from './credit.info.dto';
+
+export class CreditInfoResponseDto {
+  @ApiProperty({
+    description: '사용자의 크레딧 정보',
+  })
+  creditInfo: CreditInfoDto;
+}

--- a/backend/src/dto/generated.images.response.dto.ts
+++ b/backend/src/dto/generated.images.response.dto.ts
@@ -20,7 +20,7 @@ export class GeneratedImagesResponseDto {
   maxFreeGenerateCount: number;
 
   @ApiProperty({
-    description: '생성된 이미지 Blob 배열',
+    description: '생성된 이미지 URL 배열',
   })
-  generatedImages: Blob[];
+  generatedImages: string[];
 }

--- a/backend/src/entities/image.requests.entity.ts
+++ b/backend/src/entities/image.requests.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('image_requests')
+export class ImageRequests {
+  @PrimaryColumn({
+    type: 'int',
+    name: 'user_id',
+    unique: true,
+  })
+  userId: number;
+
+  @Column({
+    type: 'int',
+    name: 'max_request_count',
+    default: 3,
+  })
+  maxRequestCount: number;
+
+  @Column({
+    type: 'int',
+    name: 'cur_request_count',
+    default: 0,
+  })
+  curRequestCount: number;
+}

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ImageRequests } from './image.requests.entity';
 
 @Entity('user')
 export class User {
@@ -52,4 +59,8 @@ export class User {
     default: 3,
   })
   credits: number;
+
+  @OneToOne(() => ImageRequests, (imageRequests) => imageRequests.userId)
+  @JoinColumn({ name: 'user_id' })
+  imageRequests: ImageRequests;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -20,6 +20,12 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('port');
+
+  app.enableCors({
+    origin: process.env.FE_HOST,
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
   await app.listen(port);
 }
 bootstrap();

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CreditInfoResponseDto } from 'src/dto/credit.info.response.dto';
+import { UserService } from './user.service';
+import { GetUser } from 'src/decorator/user.decorator';
+import { UserDto } from 'src/dto/user.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('User')
+@Controller('users')
+export class UserController {
+  private readonly logger = new Logger(UserController.name);
+
+  constructor(private readonly userService: UserService) {}
+  @ApiOperation({
+    summary: '사용자의 크레딧 정보 조회',
+    description:
+      '사용자의 크레딧 정보를 반환합니다. 응답으로 사용자의 현재 크레딧, 현재 무료 이미지 생성 횟수, 최대 무료 이미지 생성 횟수를 반환합니다.',
+  })
+  @Get('credit-info')
+  @UseGuards(AuthGuard('jwt'))
+  async createDreamDiaryImages(
+    @GetUser() user: UserDto,
+  ): Promise<CreditInfoResponseDto> {
+    this.logger.debug(`Called ${this.createDreamDiaryImages.name}`);
+    const result = await this.userService.getUserWithImageRequestsInfo(
+      user.userId,
+    );
+    return {
+      creditInfo: {
+        credits: result.credits,
+        freeGenerateCount: result.imageRequests.curRequestCount,
+        maxFreeGenerateCount: result.imageRequests.maxRequestCount,
+      },
+    } as CreditInfoResponseDto;
+  }
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -4,9 +4,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { OAuth } from 'src/entities/oauth.entity';
 import { ImageRequests } from 'src/entities/image.requests.entity';
+import { UserController } from './user.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, OAuth, ImageRequests])],
+  controllers: [UserController],
   providers: [UserService],
   exports: [UserService],
 })

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -3,9 +3,10 @@ import { UserService } from './user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { OAuth } from 'src/entities/oauth.entity';
+import { ImageRequests } from 'src/entities/image.requests.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, OAuth])],
+  imports: [TypeOrmModule.forFeature([User, OAuth, ImageRequests])],
   providers: [UserService],
   exports: [UserService],
 })

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserDto } from 'src/dto/user.dto';
+import { ImageRequests } from 'src/entities/image.requests.entity';
 import { OAuth } from 'src/entities/oauth.entity';
 import { User } from 'src/entities/user.entity';
 import { ProviderType } from 'src/enum/provider.type';
@@ -15,6 +16,8 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(ImageRequests)
+    private readonly imageRequestsRepository: Repository<ImageRequests>,
   ) {}
   /**
    * SocialProfile을 받아서 유저를 생성하거나, 유저가 존재하면 유저 정보를 반환합니다.
@@ -76,7 +79,7 @@ export class UserService {
     );
 
     return {
-      userId: result.identifiers[0].id,
+      userId: result.identifiers[0].userId,
       nickname: user.nickname,
       imageUrl: user.imageUrl,
     };
@@ -94,5 +97,73 @@ export class UserService {
       },
     });
     return user ? true : false;
+  }
+
+  async getUserWithImageRequestsInfo(userId: number): Promise<User> {
+    this.logger.debug(`Called ${this.getUserWithImageRequestsInfo.name}`);
+
+    const result = await this.userRepository.findOne({
+      where: {
+        userId,
+      },
+      relations: ['imageRequests'],
+    });
+    return result;
+  }
+
+  /**
+   * 유저의 현재 이미지 요청 횟수를 업데이트합니다.
+   * @param userId
+   * @param curRequestCount
+   */
+  async updateUserCurRequestCount(
+    userId: number,
+    curRequestCount: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateUserCurRequestCount.name}`);
+    await this.imageRequestsRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        curRequestCount,
+      })
+      .where({
+        userId,
+      })
+      .execute();
+  }
+
+  /**
+   * 유저의 크레딧 수를 업데이트합니다.
+   * @param userId
+   * @param credits
+   */
+  async updateUserCredits(userId: number, credits: number): Promise<void> {
+    this.logger.debug(`Called ${this.updateUserCredits.name}`);
+    await this.userRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        credits,
+      })
+      .where({
+        userId,
+      })
+      .execute();
+  }
+
+  /**
+   * 모든 유저의 이미지 요청 횟수를 초기화합니다.
+   */
+  async resetAllUserImageRequests(): Promise<void> {
+    this.logger.debug(`Called ${this.resetAllUserImageRequests.name}`);
+
+    await this.imageRequestsRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        curRequestCount: 0,
+      })
+      .execute();
   }
 }

--- a/backend/src/util/openai.service.ts
+++ b/backend/src/util/openai.service.ts
@@ -20,28 +20,20 @@ export class OpenAIService {
    * @param prompt dalle에게 제공될 prompt
    * @param n 생성할 이미지의 개수
    * @param size 이미지 사이즈 (256x256, 512x512, 1024x1024)
-   * @returns 생성된 이미지의 Blob 데이터
+   * @returns 생성된 이미지의 URL 배열
    */
   async createImage(
     prompt: string,
     n: number,
     size: CreateImageRequestSizeEnum,
-  ): Promise<Blob[]> {
+  ): Promise<string[]> {
     this.logger.debug(`Called ${this.createImage.name}`);
     const response = await this.openAIApi.createImage({
       prompt,
       n,
       size,
-      response_format: 'b64_json',
+      response_format: 'url',
     });
-
-    const blobImages: Blob[] = [];
-    for (const data of response.data.data) {
-      const image = data.b64_json;
-      const decodedData = Buffer.from(image, 'base64');
-      const blob = new Blob([decodedData], { type: 'image/jpeg' });
-      blobImages.push(blob);
-    }
-    return blobImages;
+    return response.data.data.map((data) => data.url);
   }
 }

--- a/backend/src/util/system.scheduler.ts
+++ b/backend/src/util/system.scheduler.ts
@@ -1,0 +1,18 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { UserService } from 'src/user/user.service';
+
+@Injectable()
+export class SystemScheduler {
+  private readonly logger = new Logger(SystemScheduler.name);
+  constructor(private readonly userService: UserService) {}
+
+  /**
+   * 매일 자정에 사용자의 이미지 요청 횟수를 초기화합니다.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async resetImageRequests(): Promise<void> {
+    this.logger.debug(`Called ${this.resetImageRequests.name}`);
+    await this.userService.resetAllUserImageRequests();
+  }
+}

--- a/backend/src/util/util.module.ts
+++ b/backend/src/util/util.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { OpenAIService } from './openai.service';
+import { ScheduleModule } from '@nestjs/schedule';
+import { UserModule } from 'src/user/user.module';
+import { SystemScheduler } from './system.scheduler';
 
 @Module({
-  providers: [OpenAIService],
+  imports: [ScheduleModule.forRoot(), UserModule],
+  providers: [OpenAIService, SystemScheduler],
   exports: [OpenAIService],
 })
 export class UtilModule {}

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -776,6 +776,14 @@
     multer "1.4.4-lts.1"
     tslib "2.5.0"
 
+"@nestjs/schedule@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/schedule/-/schedule-2.2.2.tgz#45eab2485172317cd80eafda55842aeda37b6713"
+  integrity sha512-e9z1bbFwi4QsPkR2ix72OABhBlfRQcl4ZjF8LShlefOskR4ySN4rUzJilH+1rk8vORYDyGDurVdeduPyyfSQRg==
+  dependencies:
+    cron "2.3.0"
+    uuid "9.0.0"
+
 "@nestjs/schematics@^9.0.0", "@nestjs/schematics@^9.0.4":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@nestjs/schematics/-/schematics-9.0.4.tgz#ab612f5a8e006ca1d617eddc8143ee00b766312b"
@@ -2110,6 +2118,13 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-2.3.0.tgz#20df6da18d4f7d2f8937def2eb5fc0d1a320c526"
+  integrity sha512-ZN5HP8zDY41sJolMsbc+GksRATcbvkPKF5wR/qc8FrV4NBVi9ORQa1HmYa5GydaysUB80X9XpRlRkooa5uEtTA==
+  dependencies:
+    luxon "^3.2.1"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -3693,6 +3708,11 @@ lru-cache@^7.14.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+luxon@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 macos-release@^2.5.0:
   version "2.5.1"

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1182,6 +1182,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
   integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
 
+"@types/validator@^13.7.10":
+  version "13.7.17"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.17.tgz#0a6d1510395065171e3378a4afc587a3aefa7cc1"
+  integrity sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1880,6 +1885,20 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
+class-validator@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.14.0.tgz#40ed0ecf3c83b2a8a6a320f4edb607be0f0df159"
+  integrity sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==
+  dependencies:
+    "@types/validator" "^13.7.10"
+    libphonenumber-js "^1.10.14"
+    validator "^13.7.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -3604,6 +3623,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+libphonenumber-js@^1.10.14:
+  version "1.10.30"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.30.tgz#c0559d6c58dc1a7f189b88b7b23354c98b182848"
+  integrity sha512-PLGc+xfrQrkya/YK2/5X+bPpxRmyJBHM+xxz9krUdSgk4Vs2ZwxX5/Ow0lv3r9PDlDtNWb4u+it8MY5rZ0IyGw==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -5162,6 +5186,11 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+validator@^13.7.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.9.0.tgz#33e7b85b604f3bbce9bb1a05d5c3e22e1c2ff855"
+  integrity sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"

--- a/mariadb/dalle.sql
+++ b/mariadb/dalle.sql
@@ -307,6 +307,31 @@ LOCK TABLES `follow` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `image_requests`
+--
+
+DROP TABLE IF EXISTS `image_requests`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `image_requests` (
+  `user_id` int(11) NOT NULL,
+  `max_request_count` int(11) NOT NULL DEFAULT 3,
+  `cur_request_count` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  CONSTRAINT `image_requests_user_null_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `image_requests`
+--
+
+LOCK TABLES `image_requests` WRITE;
+/*!40000 ALTER TABLE `image_requests` DISABLE KEYS */;
+/*!40000 ALTER TABLE `image_requests` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `oauth`
 --
 
@@ -351,7 +376,7 @@ CREATE TABLE `user` (
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `nickname` (`nickname`),
   UNIQUE KEY `email` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -360,9 +385,28 @@ CREATE TABLE `user` (
 
 LOCK TABLES `user` WRITE;
 /*!40000 ALTER TABLE `user` DISABLE KEYS */;
-INSERT INTO `user` VALUES (3,'test1','test1','test1','test1',NULL,3);
 /*!40000 ALTER TABLE `user` ENABLE KEYS */;
 UNLOCK TABLES;
+/*!50003 SET @saved_cs_client      = @@character_set_client */ ;
+/*!50003 SET @saved_cs_results     = @@character_set_results */ ;
+/*!50003 SET @saved_col_connection = @@collation_connection */ ;
+/*!50003 SET character_set_client  = utf8mb4 */ ;
+/*!50003 SET character_set_results = utf8mb4 */ ;
+/*!50003 SET collation_connection  = utf8mb4_general_ci */ ;
+/*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
+/*!50003 SET sql_mode              = 'IGNORE_SPACE,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION' */ ;
+DELIMITER ;;
+/*!50003 CREATE*/ /*!50017 DEFINER=`dalle`@`%`*/ /*!50003 TRIGGER user_insert_trigger
+AFTER INSERT ON `user`
+FOR EACH ROW
+BEGIN
+  INSERT INTO image_requests (user_id) VALUES (NEW.user_id);
+END */;;
+DELIMITER ;
+/*!50003 SET sql_mode              = @saved_sql_mode */ ;
+/*!50003 SET character_set_client  = @saved_cs_client */ ;
+/*!50003 SET character_set_results = @saved_cs_results */ ;
+/*!50003 SET collation_connection  = @saved_col_connection */ ;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -373,4 +417,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-05-10 22:00:32
+-- Dump completed on 2023-05-24 22:51:09


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738


- 꿈 일기 내용과 관련된 이미지를 생성하는 API를 구현하였습니다.
최대 호출 횟수를 초과하면 크레딧을 소모하고, 크레딧까지 모두 다 소진하였다면 `401 Forbbiden`을 응답하도록 하였습니다.
- 추가로 당일 이미지 생성 횟수와 최대 무료 생성 가능 횟수, 크레딧 정보를 제공하는 API를 구현했습니다.
- 이를 위해 유저들의 해당 API 일 요청 횟수를 저장하는 `image_requests` 테이블을 추가했습니다.
- Dalle 모델 API를 사용할 수 있도록 openai와 연동하는 부분을 추가했습니다.
- 매 0시마다 모든 유저의 일 호출 횟수를 0으로 초기화하도록 스케줄링을 추가했습니다.

### P.S
- 일기 생성 시, 월 15회까지 크레딧을 획득할 수 있는 기능이 추가되어야 합니다..!
- 추후 GPT 모델이 만들어주는 프롬프트로 대체가 필요합니다.


https://github.com/CSID-DGU/2023-1-OSSP2-DALL-E-noway-2/issues/27
