### PR TITLE
[COMMON] nginx uploads 경로 proxy_pass 추가 필요

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -81,4 +81,9 @@ server {
     proxy_pass http://host.docker.internal:3000;
     proxy_set_header Host $host;
   }
+
+  location ^~ /uploads {
+    proxy_pass http://host.docker.internal:3000;
+    proxy_set_header Host $host;
+  }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

nginx conf에 /uploads 경로를 백엔드 서버로 넘겨주도록 하여, 이미지를 정상적으로 불러올 수 있도록 수정했습니다.

https://github.com/CSID-DGU/2023-1-OSSP2-DALL-E-noway-2/issues/53
