### PR TITLE
[BE] 일기 이미지 생성 프롬프트 개선

### DIFF
--- a/backend/src/dreamdiary/dreamdiary.controller.ts
+++ b/backend/src/dreamdiary/dreamdiary.controller.ts
@@ -367,6 +367,7 @@ export class DreamDiaryController {
       return await this.dreamDiaryService.createDreamDiaryImages(
         generateDreamDiaryImagesRequestDto.title,
         generateDreamDiaryImagesRequestDto.content,
+        generateDreamDiaryImagesRequestDto.n,
         user.userId,
       );
     } catch (err) {

--- a/backend/src/dreamdiary/dreamdiary.service.ts
+++ b/backend/src/dreamdiary/dreamdiary.service.ts
@@ -437,7 +437,7 @@ export class DreamDiaryService {
 
     const dallePrompt = await this.openAIService.createText(
       gptPromptForDalle,
-      'text-davinci-003',
+      'gpt-3.5-turbo',
     );
     console.log(dallePrompt);
 

--- a/backend/src/dreamdiary/dreamdiary.service.ts
+++ b/backend/src/dreamdiary/dreamdiary.service.ts
@@ -406,6 +406,7 @@ export class DreamDiaryService {
   async createDreamDiaryImages(
     title: string,
     content: string,
+    n: number,
     userId: number,
   ): Promise<GeneratedImagesResponseDto> {
     this.logger.debug(`Called ${this.createDreamDiaryImages.name}`);
@@ -415,39 +416,36 @@ export class DreamDiaryService {
     let curRequestCount = result.imageRequests.curRequestCount;
     let credits = result.credits;
 
-    if (curRequestCount + 1 > maxRequestCount) {
-      if (credits <= 0) {
+    if (curRequestCount + n > maxRequestCount) {
+      if (credits + n > 0) {
         throw new ForbiddenException(
           '무료 이미지 생성 횟수를 초과했습니다. 추가로 이용하시려면 크레딧을 충전해주세요.',
         );
       }
-      --credits;
+      credits -= n;
       await this.userService.updateUserCredits(userId, credits);
     } else {
-      ++curRequestCount;
+      curRequestCount += n;
       await this.userService.updateUserCurRequestCount(userId, curRequestCount);
     }
 
-    // TODO: prompt를 어떻게 만들어야 할지 고민해보기
-    // FIXME: GPT가 만들어주는 프롬프트로 받아서 사용해야 함.
-    title;
-    content;
-    const prompt = `
-    Captures two individuals in the office, one of them pointing a gun at the other.
-    Portray a sense of mystery and suspense.
-    Take a medium-close shot from a slightly elevated angle, providing a partial overhead view.
-    Use dim, atmospheric lighting with soft shadows. Illuminate the subject from a single source, casting intriguing highlights and shadows.
-    Create a moody ambiance with artificial lighting. Employ warm, low-intensity light resembling evening or late-night illumination.
-    Employ a wide-angle lens to capture the entire scene, providing a broader perspective.
-    Set the scene inside a corporate office, giving a sense of a real-world environment.
-    Use a digital process to enhance the image and maintain control over lighting and composition.
-    This photo could be used in a suspense or mystery-themed publication, a corporate thriller, or a psychological drama.
-`;
+    const gptPromptForDalle = this.openAIService.constructGPTPromptForDalle(
+      title,
+      content,
+    );
+    console.log(gptPromptForDalle);
 
-    // const images = await this.oepnAIService.createImage(prompt, 1, '512x512');
-    const images = [
-      'https://avatars.githubusercontent.com/u/31301280?s=200&v=4splash.com/photo-1621574539437-4b5b5b5b5b5b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMjI0NjB8MHwxfHNlYXJjaHwxfHxkcmVhbXN0aW9ufGVufDB8fHx8MTYyMjE0NjY5Mg&ixlib=rb-1.2.1&q=80&w=1080',
-    ];
+    const dallePrompt = await this.openAIService.createText(
+      gptPromptForDalle,
+      'text-davinci-003',
+    );
+    console.log(dallePrompt);
+
+    const images = await this.openAIService.createImage(
+      dallePrompt,
+      n,
+      '512x512',
+    );
 
     return {
       credits,

--- a/backend/src/dto/generate.dreamdiary.images.request.dto.ts
+++ b/backend/src/dto/generate.dreamdiary.images.request.dto.ts
@@ -12,4 +12,10 @@ export class GenerateDreamDiaryImagesRequestDto {
     description: '꿈일기 내용',
   })
   content: string;
+
+  @ApiProperty({
+    example: 3,
+    description: '생성할 이미지의 개수',
+  })
+  n: number;
 }

--- a/backend/src/util/openai.service.ts
+++ b/backend/src/util/openai.service.ts
@@ -15,6 +15,44 @@ export class OpenAIService {
   }
 
   /**
+   * Dalle 모델에게 프롬프트를 제공하기 위해 GPT 모델에게 제시할 프롬프트를 구성합니다.
+   * @param title
+   * @param content
+   * @returns GPT 모델에게 제시할 프롬프트
+   */
+  constructGPTPromptForDalle(title: string, content: string): string {
+    const prompt = `
+      다음은 유저가 작성한 꿈 일기의 제목과 내용이야.
+      이 일기의 내용을 바탕으로 텍스트를 이미지로 만들어주는 모델에게 적절한 프롬프트를 제시해주려고 해.
+      아래 지시사항을 바탕으로 해당 모델에게 제공해줄 프롬프트를 만들어줘.
+      1. 꿈 일기의 내용에서 등장하는 장소, 물체, 인물, 색상 등을 명확하게 언급해줘.
+      2. 꿈 일기의 내용에서 드러나는 감정이나 분위기에 대한 정보를 제시해줘. (고요, 신비, 활기참, 공포 등)
+      3. 필요에 따라 꿈 일기 내용에서 발생하는 (움직임, 빛, 음악 등)과 같은 감각적인 요소가 있다면 이를 강조해줘.
+
+      # 유저의 일기
+      —
+      title: ${title}
+      content: ${content}
+      —
+
+      $framing: 사진의 구도(close-up 등)
+      $flimType: 흑백 여부(black or white)
+      $emotion: 사진에서 드러나는 감정이나 분위기 정보
+      $target: 등장하는 장소나 물체, 인물 색상 등
+      $sensoryElements: 발생하는 감각적 요소 정보
+
+      # 원하는 출력 형태
+      —
+      A $framing, $flimType $emotion $target, $sensoryElements.
+      —
+
+      P.S
+      답변은 반드시 영어 400자 이내로 해줘.
+    `;
+    return prompt;
+  }
+
+  /**
    * OpenAI의 Dalle API를 이용해 이미지를 생성합니다.
    *
    * @param prompt dalle에게 제공될 prompt
@@ -35,6 +73,22 @@ export class OpenAIService {
       response_format: 'url',
     });
     return response.data.data.map((data) => data.url);
+  }
+
+  /**
+   * OpenAI의 텍스트 생성 API를 이용해 답변을 생성합니다.
+   * @param prompt GPT 모델에게 제공할 프롬프트
+   */
+  async createText(prompt: string, model: string): Promise<string> {
+    this.logger.debug(`Called ${this.createText.name}`);
+    const response = await this.openAIApi.createCompletion({
+      prompt,
+      model,
+      max_tokens: 1000,
+      temperature: 0.3,
+      n: 1,
+    });
+    return response.data.choices[0].text.trim();
   }
 
   /**

--- a/backend/src/util/openai.service.ts
+++ b/backend/src/util/openai.service.ts
@@ -81,14 +81,19 @@ export class OpenAIService {
    */
   async createText(prompt: string, model: string): Promise<string> {
     this.logger.debug(`Called ${this.createText.name}`);
-    const response = await this.openAIApi.createCompletion({
-      prompt,
+
+    const response = await this.openAIApi.createChatCompletion({
       model,
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
       max_tokens: 1000,
-      temperature: 0.3,
-      n: 1,
+      temperature: 0,
     });
-    return response.data.choices[0].text.trim();
+    return response.data.choices[0].message.content.trim();
   }
 
   /**

--- a/frontend/src/api/axios.custom.ts
+++ b/frontend/src/api/axios.custom.ts
@@ -12,10 +12,15 @@ export const postDreamDiary = async (dreamDiaryCreateRequest: FormData) => {
 };
 
 const postDreamImageUrl = '/api/dream-diary/dream-images';
-export const postDreamImage = async (title: string, content: string) => {
+export const postDreamImage = async (
+  title: string,
+  content: string,
+  n: number,
+) => {
   const response = await axiosInstance.post(postDreamImageUrl, {
     title,
     content,
+    n,
   });
   return response;
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

일기 이미지 생성 API에서 프롬프트를 개선하고, GPT로부터 프롬프트를 생성하도록 코드를 변경했습니다.
text-davini 모델로는 dalle에 사용하기에 적절한 프롬프트가 잘 안만들어져서 gpt-turbo-3.5를 이용했습니다.
또한 생성할 일기의 개수를 클라이언트에서 지정할 수 있도록 수정했습니다.
이에 맞게 프론트에서도 개수를 입력할 수 있는 UI를 구현하고, 전체적으로 이미지 생성 뷰도 개선시켰습니다.

https://github.com/CSID-DGU/2023-1-OSSP2-DALL-E-noway-2/issues/81
