### PR TITLE
[BE] 꿈일기 통계 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { join } from 'path';
 import { CategoryModule } from './category/category.module';
 import { LikeBookmarkListModule } from './likebookmarklist/likebookmarklist.module';
 import { CommentModule } from './comment/comment.module';
+import { StatModule } from './dreamdiary/calendar/stat/stat.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { CommentModule } from './comment/comment.module';
     CategoryModule,
     LikeBookmarkListModule,
     ProfileModule,
+    StatModule,
   ],
 
   controllers: [AppController],

--- a/backend/src/dreamdiary/calendar/stat/stat.controller.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.controller.ts
@@ -12,6 +12,7 @@ import { GetUser } from 'src/decorator/user.decorator';
 import { UserDto } from 'src/dto/user.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { DreamDiaryCategoryScoreAvg } from 'src/dto/stat.score.avg.response.dto';
 
 @ApiTags('Stat')
 @Controller('stat')
@@ -34,5 +35,20 @@ export class StatController {
       year,
       month,
     );
+  }
+
+  // 추가된 메소드
+  @ApiOperation({
+    summary: '유저의 꿈 일기 카테고리별 평균 점수',
+    description: '유저의 꿈 일기 카테고리별 평균 점수를 반환합니다.',
+  })
+  @UseGuards(AuthGuard('jwt'))
+  @Get('categories/score')
+  async getUserDreamDiaryScoreAvg(
+    @GetUser() user: UserDto,
+    @Query('year', ParseIntPipe) year: number,
+    @Query('month', ParseIntPipe) month: number,
+  ): Promise<DreamDiaryCategoryScoreAvg[]> {
+    return this.statService.getUserDreamDiaryScoreAvg(user.userId, year, month);
   }
 }

--- a/backend/src/dreamdiary/calendar/stat/stat.controller.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.controller.ts
@@ -1,0 +1,38 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { StatService } from './stat.service';
+import { DreamDiaryCategoryCount } from 'src/dto/stat.category.count.response.dto';
+import { GetUser } from 'src/decorator/user.decorator';
+import { UserDto } from 'src/dto/user.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+
+@ApiTags('Stat')
+@Controller('stat')
+export class StatController {
+  constructor(private readonly statService: StatService) {}
+
+  @ApiOperation({
+    summary: '유저의 꿈 일기 카테고리별 통계',
+    description: '유저의 꿈 일기 카테고리별 통계를 반환합니다.',
+  })
+  @UseGuards(AuthGuard('jwt'))
+  @Get('categories/count')
+  async getUserDreamDiaryCategoryCounts(
+    @GetUser() user: UserDto,
+    @Query('year', ParseIntPipe) year: number,
+    @Query('month', ParseIntPipe) month: number,
+  ): Promise<DreamDiaryCategoryCount[]> {
+    return this.statService.getUserDreamDiaryCategoryCounts(
+      user.userId,
+      year,
+      month,
+    );
+  }
+}

--- a/backend/src/dreamdiary/calendar/stat/stat.controller.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  Param,
   ParseIntPipe,
   Query,
   UseGuards,
@@ -13,6 +12,7 @@ import { UserDto } from 'src/dto/user.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { DreamDiaryCategoryScoreAvg } from 'src/dto/stat.score.avg.response.dto';
+import { DreamScoreAverageResponseDto } from 'src/dto/stat.total.score.avg.dto';
 
 @ApiTags('Stat')
 @Controller('stat')
@@ -50,5 +50,20 @@ export class StatController {
     @Query('month', ParseIntPipe) month: number,
   ): Promise<DreamDiaryCategoryScoreAvg[]> {
     return this.statService.getUserDreamDiaryScoreAvg(user.userId, year, month);
+  }
+
+  @ApiOperation({
+    summary: '유저의 꿈 일기 점수 평균과 다른 사용자들의 꿈 일기 점수 평균',
+    description:
+      '유저의 꿈 일기 점수 평균과 다른 사용자들의 꿈 일기 점수 평균을 반환합니다.',
+  })
+  @UseGuards(AuthGuard('jwt'))
+  @Get('average')
+  async getDreamScoreAverage(
+    @GetUser() user: UserDto,
+    @Query('year', ParseIntPipe) year: number,
+    @Query('month', ParseIntPipe) month: number,
+  ): Promise<DreamScoreAverageResponseDto> {
+    return this.statService.getDreamScoreAverage(user.userId, year, month);
   }
 }

--- a/backend/src/dreamdiary/calendar/stat/stat.module.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StatController } from './stat.controller';
+import { StatService } from './stat.service';
+import { User } from 'src/entities/user.entity';
+import { DiaryCategory } from 'src/entities/diary.category.entity';
+import { Category } from 'src/entities/category.entity';
+import { DreamDiary } from 'src/entities/dream.diary.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, DiaryCategory, Category, DreamDiary]),
+  ],
+  controllers: [StatController],
+  providers: [StatService],
+})
+export class StatModule {}

--- a/backend/src/dreamdiary/calendar/stat/stat.service.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DreamDiaryCategoryCount } from 'src/dto/stat.category.count.response.dto';
+import { DreamDiaryCategoryScoreAvg } from 'src/dto/stat.score.avg.response.dto';
 import { Category } from 'src/entities/category.entity';
 import { DiaryCategory } from 'src/entities/diary.category.entity';
 import { DreamDiary } from 'src/entities/dream.diary.entity';
@@ -32,8 +33,10 @@ export class StatService {
       const categoryCounts = await this.dreamDiaryRepository
         .createQueryBuilder('dream_diary')
         .select('categories.categoryId', 'categoryId')
+        .addSelect('categories.categoryName', 'categoryName')
         .addSelect('COUNT(*)', 'count')
-        .innerJoin('dream_diary.diaryCategories', 'categories')
+        .innerJoin('dream_diary.diaryCategories', 'diaryCategories')
+        .innerJoin('diaryCategories.category', 'categories')
         .innerJoin('dream_diary.author', 'user')
         .where('user.userId = :userId', { userId })
         .andWhere('dream_diary.createdAt >= :startDate', { startDate })
@@ -42,6 +45,36 @@ export class StatService {
         .getRawMany();
 
       return categoryCounts;
+    } catch (error) {
+      console.error(error);
+      throw new Error(error.message || 'Internal Server Error');
+    }
+  }
+
+  async getUserDreamDiaryScoreAvg(
+    userId: number,
+    year: number,
+    month: number,
+  ): Promise<DreamDiaryCategoryScoreAvg[]> {
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 0);
+
+    try {
+      const categoryScoreAvgs = await this.dreamDiaryRepository
+        .createQueryBuilder('dream_diary')
+        .select('categories.categoryId', 'categoryId')
+        .addSelect('categories.categoryName', 'categoryName')
+        .addSelect('ROUND(AVG(dream_diary.dreamScore), 1)', 'scoreAvg')
+        .innerJoin('dream_diary.diaryCategories', 'diaryCategories')
+        .innerJoin('diaryCategories.category', 'categories')
+        .innerJoin('dream_diary.author', 'user')
+        .where('user.userId = :userId', { userId })
+        .andWhere('dream_diary.createdAt >= :startDate', { startDate })
+        .andWhere('dream_diary.createdAt <= :endDate', { endDate })
+        .groupBy('categories.categoryId')
+        .getRawMany();
+
+      return categoryScoreAvgs;
     } catch (error) {
       console.error(error);
       throw new Error(error.message || 'Internal Server Error');

--- a/backend/src/dreamdiary/calendar/stat/stat.service.ts
+++ b/backend/src/dreamdiary/calendar/stat/stat.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DreamDiaryCategoryCount } from 'src/dto/stat.category.count.response.dto';
+import { Category } from 'src/entities/category.entity';
+import { DiaryCategory } from 'src/entities/diary.category.entity';
+import { DreamDiary } from 'src/entities/dream.diary.entity';
+import { User } from 'src/entities/user.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class StatService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(DiaryCategory)
+    private readonly diaryCategoryRepository: Repository<DiaryCategory>,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+    @InjectRepository(DreamDiary)
+    private readonly dreamDiaryRepository: Repository<DreamDiary>,
+  ) {}
+
+  async getUserDreamDiaryCategoryCounts(
+    userId: number,
+    year: number,
+    month: number,
+  ): Promise<DreamDiaryCategoryCount[]> {
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 0);
+
+    try {
+      const categoryCounts = await this.dreamDiaryRepository
+        .createQueryBuilder('dream_diary')
+        .select('categories.categoryId', 'categoryId')
+        .addSelect('COUNT(*)', 'count')
+        .innerJoin('dream_diary.diaryCategories', 'categories')
+        .innerJoin('dream_diary.author', 'user')
+        .where('user.userId = :userId', { userId })
+        .andWhere('dream_diary.createdAt >= :startDate', { startDate })
+        .andWhere('dream_diary.createdAt <= :endDate', { endDate })
+        .groupBy('categories.categoryId')
+        .getRawMany();
+
+      return categoryCounts;
+    } catch (error) {
+      console.error(error);
+      throw new Error(error.message || 'Internal Server Error');
+    }
+  }
+}

--- a/backend/src/dto/stat.category.count.response.dto.ts
+++ b/backend/src/dto/stat.category.count.response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 꿈 일기 카테고리별 통계를 담는 DTO입니다.
+ */
+export class DreamDiaryCategoryCount {
+  @ApiProperty({
+    example: 1,
+    description: '카테고리 아이디',
+  })
+  categoryId: string;
+
+  @ApiProperty({
+    example: 1,
+    description: '카테고리별 꿈 일기 개수',
+  })
+  count: number;
+}

--- a/backend/src/dto/stat.category.count.response.dto.ts
+++ b/backend/src/dto/stat.category.count.response.dto.ts
@@ -11,6 +11,12 @@ export class DreamDiaryCategoryCount {
   categoryId: string;
 
   @ApiProperty({
+    example: '악몽',
+    description: '카테고리 이름',
+  })
+  categoryName: string;
+
+  @ApiProperty({
     example: 1,
     description: '카테고리별 꿈 일기 개수',
   })

--- a/backend/src/dto/stat.score.avg.response.dto.ts
+++ b/backend/src/dto/stat.score.avg.response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DreamDiaryCategoryScoreAvg {
+  @ApiProperty({ example: 1, description: '카테고리 ID' })
+  categoryId: number;
+
+  @ApiProperty({
+    example: '악몽',
+    description: '카테고리 이름',
+  })
+  categoryName: string;
+
+  @ApiProperty({ example: 4.5, description: '평균 점수' })
+  scoreAvg: number;
+}

--- a/backend/src/dto/stat.total.score.avg.dto.ts
+++ b/backend/src/dto/stat.total.score.avg.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DreamScoreAverageResponseDto {
+  @ApiProperty({ example: 4.5, description: '나의 꿈 일기 평균 점수' })
+  myAvgScore: number;
+
+  @ApiProperty({
+    example: 4.5,
+    description: '다른 사용자들의 꿈 일기 평균 점수',
+  })
+  othersAvgScore: number;
+}

--- a/backend/src/entities/diary.category.entity.ts
+++ b/backend/src/entities/diary.category.entity.ts
@@ -1,5 +1,28 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+// import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+// import { Category } from './category.entity';
+
+// @Entity('diary_category')
+// export class DiaryCategory {
+//   @PrimaryColumn({
+//     type: 'int',
+//     name: 'diary_id',
+//   })
+//   diaryId: number;
+
+//   @PrimaryColumn({
+//     type: 'int',
+//     name: 'category_id',
+//   })
+//   categoryId: number;
+
+//   @ManyToOne(() => Category, (category) => category.categoryId)
+//   @JoinColumn({ name: 'category_id' })
+//   category: Category;
+// }
+
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Category } from './category.entity';
+import { DreamDiary } from './dream.diary.entity';
 
 @Entity('diary_category')
 export class DiaryCategory {
@@ -14,6 +37,10 @@ export class DiaryCategory {
     name: 'category_id',
   })
   categoryId: number;
+
+  @ManyToOne(() => DreamDiary, (dreamDiary) => dreamDiary.diaryCategories)
+  @JoinColumn({ name: 'diary_id' })
+  dreamDiary: DreamDiary;
 
   @ManyToOne(() => Category, (category) => category.categoryId)
   @JoinColumn({ name: 'category_id' })

--- a/backend/src/entities/dream.diary.entity.ts
+++ b/backend/src/entities/dream.diary.entity.ts
@@ -1,3 +1,99 @@
+// import { DisclosureScopeType } from 'src/enum/disclosure.scope.type';
+// import {
+//   Column,
+//   Entity,
+//   JoinColumn,
+//   ManyToOne,
+//   OneToMany,
+//   PrimaryGeneratedColumn,
+// } from 'typeorm';
+// import { User } from './user.entity';
+// import { DiaryCategory } from './diary.category.entity';
+
+// @Entity('dream_diary')
+// export class DreamDiary {
+//   @PrimaryGeneratedColumn({
+//     type: 'int',
+//     name: 'diary_id',
+//   })
+//   diaryId: number;
+
+//   @Column({
+//     type: 'int',
+//     name: 'user_id',
+//     unique: true,
+//   })
+//   userId: number;
+
+//   @Column({
+//     type: 'varchar',
+//     name: 'title',
+//     length: 255,
+//   })
+//   title: string;
+
+//   @Column({
+//     type: 'text',
+//     name: 'content',
+//   })
+//   content: string;
+
+//   @Column({
+//     type: 'tinyint',
+//     name: 'dream_score',
+//   })
+//   dreamScore: number;
+
+//   @Column({
+//     type: 'int',
+//     name: 'view_count',
+//     default: 0,
+//   })
+//   viewCount: number;
+
+//   @Column({
+//     type: 'datetime',
+//     name: 'created_at',
+//     default: () => 'CURRENT_TIMESTAMP',
+//   })
+//   createdAt: Date;
+
+//   @Column({
+//     type: 'datetime',
+//     name: 'updated_at',
+//     nullable: true,
+//   })
+//   updatedAt: Date;
+
+//   @Column({
+//     type: 'varchar',
+//     name: 'image_url',
+//     length: 255,
+//   })
+//   imageUrl: string;
+
+//   @Column({
+//     type: 'enum',
+//     name: 'disclosure_scope',
+//     enum: DisclosureScopeType,
+//   })
+//   disclosureScope: DisclosureScopeType;
+
+//   @Column({
+//     type: 'text',
+//     name: 'interpretation',
+//     nullable: true,
+//   })
+//   interpretation: string;
+
+//   @ManyToOne(() => User, (user) => user.userId)
+//   @JoinColumn({ name: 'user_id' })
+//   author: User;
+
+//   @OneToMany(() => DiaryCategory, (diaryCategory) => diaryCategory.diaryId)
+//   diaryCategories: DiaryCategory[];
+// }
+
 import { DisclosureScopeType } from 'src/enum/disclosure.scope.type';
 import {
   Column,
@@ -90,6 +186,6 @@ export class DreamDiary {
   @JoinColumn({ name: 'user_id' })
   author: User;
 
-  @OneToMany(() => DiaryCategory, (diaryCategory) => diaryCategory.diaryId)
+  @OneToMany(() => DiaryCategory, (diaryCategory) => diaryCategory.dreamDiary)
   diaryCategories: DiaryCategory[];
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

유저의 한달간 카테고리별 꿈일기 빈도 수, 카테고리별 평균 점수, 내가 한달간 작성한 꿈일기 평균 점수와 다른 유저의 평균 점수를 반환하는 API를 구현하였습니다.

https://github.com/CSID-DGU/2023-1-OSSP2-DALL-E-noway-2/issues/83
