### PR TITLE
[FE] 프로필 뷰에서 꿈일기 피드, 게시글 목록 구현

### DIFF
--- a/frontend/src/api/axios.custom.ts
+++ b/frontend/src/api/axios.custom.ts
@@ -118,6 +118,29 @@ export const updateProfileRequest = async (
   return response;
 };
 
+export const getUserDiaryFeeds = async (
+  userId: number,
+  page: number,
+  length: number,
+) => {
+  const response = await axiosInstance.get(
+    `/api/users/${userId}/dream-diary/feeds?page=${page}&length=${length}`,
+  );
+  return response;
+};
+
+export const getUserBoards = async (
+  userId: number,
+  boardType: BoardType,
+  page: number,
+  length: number,
+) => {
+  const response = await axiosInstance.get(
+    `/api/users/${userId}/${boardType}/boards/?page=${page}&length=${length}`,
+  );
+  return response;
+};
+
 export const getAllComments = async (filterType: string, id: number) => {
   const response = await axiosInstance.get(`/api/comments/${filterType}/${id}`);
   return response;

--- a/frontend/src/types/enum/filter.type.ts
+++ b/frontend/src/types/enum/filter.type.ts
@@ -1,0 +1,6 @@
+export enum FilterType {
+  DIARY = 'DIARY',
+  FREE = 'FREE',
+  TIP = 'TIP',
+  REQUEST = 'REQUEST',
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -82,6 +82,14 @@ export interface DiaryFeed {
   viewCount: number;
 }
 
+export interface Board {
+  postId: number;
+  title: string;
+  viewCount: number;
+  nickname: string;
+  imageUrl: string;
+}
+
 // 카테고리 별 개수 통계
 export interface CountStat {
   categoryId: number;

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -16,7 +16,7 @@ const selectedFilterType: Ref<FilterType> = ref(FilterType.DIARY);
 const diaryFeeds: Ref<DiaryFeed[]> = ref([]);
 const boardList: Ref<Board[]> = ref([]);
 
-const MAX_LENGTH = 2;
+const MAX_LENGTH = 4;
 
 const truncateContent = (content: string, maxLength: number) => {
   if (content.length <= maxLength) {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -6,6 +6,8 @@ import { onMounted, ref, watch, type Ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { getUserDiaryFeeds, getUserBoards } from '@/api/axios.custom';
 import type { BoardType } from '@/types/enum/board.type';
+// @ts-ignore
+import InfiniteLoading from 'v3-infinite-loading';
 
 const { params } = useRoute();
 const userId = Number(params.userId);
@@ -13,6 +15,16 @@ const userId = Number(params.userId);
 const selectedFilterType: Ref<FilterType> = ref(FilterType.DIARY);
 const diaryFeeds: Ref<DiaryFeed[]> = ref([]);
 const boardList: Ref<Board[]> = ref([]);
+
+const MAX_LENGTH = 2;
+
+const truncateContent = (content: string, maxLength: number) => {
+  if (content.length <= maxLength) {
+    return content;
+  } else {
+    return content.slice(0, maxLength) + '...';
+  }
+};
 
 const initDiaryFeeds = async (page: number, length: number) => {
   try {
@@ -67,23 +79,118 @@ const initBoardList = async (
   }
 };
 
+const curDiaryPage = ref(1);
+
+const fetchDiaryFeeds = async (page: number, length: number) => {
+  try {
+    const response = await getUserDiaryFeeds(userId, page, length);
+    const results = response.data;
+    if (response.status === 200) {
+      // response.data의 각 요소 중 diaryImageUrl을 diaryFeeds의 각 요소 중 imageUrl로 옮겨줌
+      for (let i = 0; i < results.dreamDiaryFeeds.length; i += 1) {
+        diaryFeeds.value.push({
+          diaryId: results.dreamDiaryFeeds[i].diaryId,
+          title: results.dreamDiaryFeeds[i].title,
+          content: results.dreamDiaryFeeds[i].content,
+          nickname: results.dreamDiaryFeeds[i].nickname,
+          viewCount: results.dreamDiaryFeeds[i].viewCount,
+          imageUrl: results.dreamDiaryFeeds[i].diaryImageUrl,
+        });
+      }
+    } else {
+      console.log(response);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// @ts-ignore
+const loadMoreDiary = async ($state) => {
+  try {
+    const response = await getUserDiaryFeeds(
+      userId,
+      // @ts-ignore
+      curDiaryPage.value + 1,
+      MAX_LENGTH,
+    );
+    const results = response.data;
+    if (response.status === 200) {
+      // response.data의 각 요소 중 diaryImageUrl을 diaryFeeds의 각 요소 중 imageUrl로 옮겨줌
+      for (let i = 0; i < results.dreamDiaryFeeds.length; i += 1) {
+        diaryFeeds.value.push({
+          diaryId: results.dreamDiaryFeeds[i].diaryId,
+          title: results.dreamDiaryFeeds[i].title,
+          content: results.dreamDiaryFeeds[i].content,
+          nickname: results.dreamDiaryFeeds[i].nickname,
+          viewCount: results.dreamDiaryFeeds[i].viewCount,
+          imageUrl: results.dreamDiaryFeeds[i].diaryImageUrl,
+        });
+      }
+      if (response.data.dreamDiaryFeeds.length < MAX_LENGTH) {
+        $state.complete();
+      } else {
+        $state.loaded();
+      }
+      ++curDiaryPage.value;
+    }
+    console.log(`curDiaryPage: ${curDiaryPage.value}`);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const curBoardPage = ref(1);
+
+// @ts-ignore
+const loadMoreBoard = async ($state) => {
+  try {
+    const response = await getUserBoards(
+      userId,
+      // @ts-ignore
+      selectedFilterType.value as BoardType,
+      curBoardPage.value + 1,
+      MAX_LENGTH,
+    );
+    const results = response.data;
+    if (response.status === 200) {
+      // response.data의 각 요소 중 boardImageUrl을 boardList의 각 요소 중 imageUrl로 옮겨줌
+      for (let i = 0; i < results.boardList.length; i += 1) {
+        boardList.value.push({
+          postId: results.boardList[i].postId,
+          title: results.boardList[i].title,
+          nickname: results.boardList[i].nickname,
+          viewCount: results.boardList[i].viewCount,
+          imageUrl: results.boardList[i].boardImageUrl,
+        });
+      }
+      if (response.data.boardList.length < MAX_LENGTH) {
+        $state.complete();
+      } else {
+        $state.loaded();
+      }
+      ++curBoardPage.value;
+    }
+    console.log(`curBoardPage: ${curBoardPage.value}`);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 watch(
   () => selectedFilterType.value,
   async (value) => {
     if (value === FilterType.DIARY) {
-      await initDiaryFeeds(1, 10);
+      await initDiaryFeeds(1, MAX_LENGTH);
     } else {
       // @ts-ignore
-      await initBoardList(value as BoardType, 1, 10);
+      await initBoardList(value as BoardType, 1, MAX_LENGTH);
     }
-    console.log(diaryFeeds.value);
-    console.log(boardList.value);
   },
 );
 
 onMounted(async () => {
-  await initDiaryFeeds(1, 10);
-  console.log(diaryFeeds.value);
+  await initDiaryFeeds(1, MAX_LENGTH);
 });
 </script>
 
@@ -132,13 +239,14 @@ onMounted(async () => {
               <h2 class="feed-title">{{ diaryFeed.title }}</h2>
               <p class="feed-user">{{ diaryFeed.nickname }}</p>
               <p class="feed-content">
-                {{ diaryFeed.content }}
+                {{ truncateContent(diaryFeed.content, 25) }}
               </p>
               <p class="feed-view">👀 {{ diaryFeed.viewCount }}</p>
               <img :src="diaryFeed.imageUrl" alt="Post Image" />
             </RouterLink>
           </div>
         </div>
+        <InfiniteLoading @infinite="loadMoreDiary"></InfiniteLoading>
       </div>
     </div>
 
@@ -158,6 +266,7 @@ onMounted(async () => {
             </div>
           </RouterLink>
         </div>
+        <InfiniteLoading @infinite="loadMoreBoard"></InfiniteLoading>
       </div>
     </div>
   </div>
@@ -189,19 +298,26 @@ onMounted(async () => {
   @apply justify-center py-2 text-white;
 }
 
+/* 일기 */
 .diary-container {
   @apply flex overflow-y-auto;
 }
 
-/* 일기 */
 .diary-list {
   @apply flex-shrink-0;
   @apply w-full h-[500px];
+  color: white;
+  width: 84%;
+  margin: 0 auto;
 }
 
 .diary-card {
-  @apply text-white;
-  @apply m-4;
+  /* @apply text-white;
+  @apply m-4; */
+  @apply flex flex-row justify-between;
+  @apply border-solid border-white;
+  border-width: 1px 0;
+  @apply p-3;
 }
 
 .diary-card tag {
@@ -209,7 +325,7 @@ onMounted(async () => {
 }
 
 .diary-card img {
-  @apply w-full h-full;
+  @apply w-32 h-32;
   @apply rounded-2xl;
 }
 .feed-title {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,46 +1,270 @@
 <script setup lang="ts">
 import ProfileBar from '@/components/profile/ProfileBar.vue';
+import type { Board, DiaryFeed } from '@/types';
+import { FilterType } from '@/types/enum/filter.type';
+import { onMounted, ref, watch, type Ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { getUserDiaryFeeds, getUserBoards } from '@/api/axios.custom';
+import type { BoardType } from '@/types/enum/board.type';
 
 const { params } = useRoute();
 const userId = Number(params.userId);
+
+const selectedFilterType: Ref<FilterType> = ref(FilterType.DIARY);
+const diaryFeeds: Ref<DiaryFeed[]> = ref([]);
+const boardList: Ref<Board[]> = ref([]);
+
+const initDiaryFeeds = async (page: number, length: number) => {
+  try {
+    const response = await getUserDiaryFeeds(userId, page, length);
+    const results = response.data;
+    if (response.status === 200) {
+      diaryFeeds.value = [];
+      // response.data의 각 요소 중 diaryImageUrl을 diaryFeeds의 각 요소 중 imageUrl로 옮겨줌
+      for (let i = 0; i < results.dreamDiaryFeeds.length; i += 1) {
+        diaryFeeds.value.push({
+          diaryId: results.dreamDiaryFeeds[i].diaryId,
+          title: results.dreamDiaryFeeds[i].title,
+          content: results.dreamDiaryFeeds[i].content,
+          nickname: results.dreamDiaryFeeds[i].nickname,
+          viewCount: results.dreamDiaryFeeds[i].viewCount,
+          imageUrl: results.dreamDiaryFeeds[i].diaryImageUrl,
+        });
+      }
+    } else {
+      console.log(response);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const initBoardList = async (
+  boardtype: BoardType,
+  page: number,
+  length: number,
+) => {
+  try {
+    const response = await getUserBoards(userId, boardtype, page, length);
+    const results = response.data;
+    if (response.status === 200) {
+      // response.data의 각 요소 중 boardImageUrl을 boardList의 각 요소 중 imageUrl로 옮겨줌
+      boardList.value = [];
+      for (let i = 0; i < results.boardList.length; i += 1) {
+        boardList.value.push({
+          postId: results.boardList[i].postId,
+          title: results.boardList[i].title,
+          nickname: results.boardList[i].nickname,
+          viewCount: results.boardList[i].viewCount,
+          imageUrl: results.boardList[i].boardImageUrl,
+        });
+      }
+    } else {
+      console.log(response);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+watch(
+  () => selectedFilterType.value,
+  async (value) => {
+    if (value === FilterType.DIARY) {
+      await initDiaryFeeds(1, 10);
+    } else {
+      // @ts-ignore
+      await initBoardList(value as BoardType, 1, 10);
+    }
+    console.log(diaryFeeds.value);
+    console.log(boardList.value);
+  },
+);
+
+onMounted(async () => {
+  await initDiaryFeeds(1, 10);
+  console.log(diaryFeeds.value);
+});
 </script>
 
 <template>
   <div class="wrap">
     <ProfileBar :userId="userId" />
+    <div class="filter-type-bar">
+      <div
+        class="filter-type-content"
+        :class="{ selected: selectedFilterType === FilterType.DIARY }"
+        @click="selectedFilterType = FilterType.DIARY"
+      >
+        <h1>꿈일기</h1>
+      </div>
+
+      <div
+        class="filter-type-content"
+        :class="{ selected: selectedFilterType === FilterType.FREE }"
+        @click="selectedFilterType = FilterType.FREE"
+      >
+        <h1>자유</h1>
+      </div>
+
+      <div
+        class="filter-type-content"
+        :class="{ selected: selectedFilterType === FilterType.TIP }"
+        @click="selectedFilterType = FilterType.TIP"
+      >
+        <h1>수면 팁</h1>
+      </div>
+
+      <div
+        class="filter-type-content"
+        :class="{ selected: selectedFilterType === FilterType.REQUEST }"
+        @click="selectedFilterType = FilterType.REQUEST"
+      >
+        <h1>해몽 의뢰</h1>
+      </div>
+    </div>
+
+    <div class="diary-container">
+      <div v-if="selectedFilterType === FilterType.DIARY" class="diary-list">
+        <div v-for="diaryFeed in diaryFeeds" :key="diaryFeed.diaryId">
+          <div class="diary-card">
+            <RouterLink :to="`/dream-diary/${diaryFeed.diaryId}`">
+              <h2 class="feed-title">{{ diaryFeed.title }}</h2>
+              <p class="feed-user">{{ diaryFeed.nickname }}</p>
+              <p class="feed-content">
+                {{ diaryFeed.content }}
+              </p>
+              <p class="feed-view">👀 {{ diaryFeed.viewCount }}</p>
+              <img :src="diaryFeed.imageUrl" alt="Post Image" />
+            </RouterLink>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="board-container">
+      <div v-if="selectedFilterType === FilterType.FREE" class="board-list">
+        <div v-for="board in boardList" :key="board.postId">
+          <RouterLink :to="`/board/${board.postId}`">
+            <div class="board-card">
+              <div class="board-card-left">
+                <h2 class="board-title">{{ board.title }}</h2>
+                <p class="board-user">{{ board.nickname }}</p>
+                <p class="board-view">👀 {{ board.viewCount }}</p>
+              </div>
+              <div class="board-card-right">
+                <img :src="board.imageUrl" alt="Post Image" />
+              </div>
+            </div>
+          </RouterLink>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .wrap {
+  @apply relative;
+  @apply overflow-y-auto;
   @apply w-full flex flex-col justify-center h-full z-[1];
 }
 
-.row-group {
+/* 필터 선택 바 */
+.filter-type-bar {
+  @apply w-full flex flex-row justify-center h-full;
+  @apply bg-black text-white;
+}
+
+.filter-type-content {
+  @apply justify-center py-2 text-gray-500;
+  @apply m-3;
+}
+
+.filter-type-content.selected {
+  @apply justify-center py-2 text-white;
+}
+
+.filter-type-content:hover {
+  @apply justify-center py-2 text-white;
+}
+
+.diary-container {
+  @apply flex overflow-y-auto;
+}
+
+/* 일기 */
+.diary-list {
+  @apply flex-shrink-0;
+  @apply w-full h-[500px];
+}
+
+.diary-card {
+  @apply text-white;
+  @apply m-4;
+}
+
+.diary-card tag {
+  @apply m-2;
+}
+
+.diary-card img {
+  @apply w-full h-full;
+  @apply rounded-2xl;
+}
+.feed-title {
+  @apply text-2xl font-bold;
+}
+.feed-view {
   @apply flex flex-row;
 }
 
-.row-item {
-  @apply m-0.5;
-}
-/* .row-item:nth-child(1) {
-  flex: 2;
-}
+/* 기타 게시글 */
 
-.row-item:nth-child(2) {
-  flex: 3;
+.board-container {
+  @apply flex overflow-y-auto;
 }
 
-.row-item:nth-child(3) {
-  flex: 3;
-} */
+.board-list {
+  @apply flex-shrink-0;
+  @apply w-full h-[500px];
+  color: white;
+  width: 84%;
+  margin: 0 auto;
+}
 
-.col-group {
+.board-card {
+  @apply flex flex-row justify-between;
+  @apply border-solid border-white;
+  border-width: 1px 0;
+  @apply p-3;
+}
+
+.board-card-left {
   @apply flex flex-col;
+  margin-right: 10px;
+  font-size: 12px;
+  left: 0;
 }
 
-.col-item {
-  @apply m-0.5 text-center text-white;
+.board-card-right {
+}
+
+.board-card tag {
+  @apply m-2;
+}
+
+.board-card img {
+  @apply w-full h-full;
+  @apply rounded-2xl;
+  max-width: 84px;
+  height: 60px;
+  border-radius: 8px;
+}
+.board-title {
+  @apply text-2xl font-bold;
+}
+.board-view {
+  @apply flex flex-row;
 }
 </style>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

프로필 뷰에서 꿈일기 피드, 게시글 목록 구현했습니다. 
팔로우에서와 마찬가지로 무한 스크롤을 이용해서 다 읽으면 다음 페이지를 새로 요청하도록 구현했습니다.
다만 4개정도씩 불러올 때 보기가 편한 것 같아 한 번에 불러올 개수를 10 -> 4로 수정했습니다.

https://github.com/CSID-DGU/2023-1-OSSP2-DALL-E-noway-2/issues/41
